### PR TITLE
multi-row values to speed up database insertion

### DIFF
--- a/firepit/splitter.py
+++ b/firepit/splitter.py
@@ -145,12 +145,12 @@ class SqlWriter:
         try:
             cursor = self.store.connection.cursor()
             cursor.execute('BEGIN')
-            for obj in records:
-                if replace:
+            if replace:
+                for obj in records:
                     self._replace(cursor, tablename, obj)
-                else:
-                    #self._insert(cursor, tablename, obj)
-                    self.store.upsert(cursor, tablename, obj, query_id)
+            else:
+                #self._insert(cursor, tablename, obj)
+                self.store.upsert(cursor, tablename, records, query_id)
             cursor.execute('COMMIT')
         finally:
             cursor.close()

--- a/firepit/splitter.py
+++ b/firepit/splitter.py
@@ -149,8 +149,7 @@ class SqlWriter:
                 for obj in records:
                     self._replace(cursor, tablename, obj)
             else:
-                #self._insert(cursor, tablename, obj)
-                self.store.upsert(cursor, tablename, records, query_id)
+                self.store.upsert_many(cursor, tablename, records, query_id)
             cursor.execute('COMMIT')
         finally:
             cursor.close()

--- a/firepit/sqlstorage.py
+++ b/firepit/sqlstorage.py
@@ -199,11 +199,7 @@ class SqlStorage:
         self.connection.commit()
         cursor.close()
 
-    def upsert(self, cursor, tablename, objs, query_id):
-        cols = set()
-        for obj in objs:
-            cols = cols.union(obj.keys())
-        colnames = list(cols)
+    def _get_excluded(self, colnames, tablename):
         excluded = []
         for col in colnames:
             if col == 'first_observed':
@@ -216,30 +212,28 @@ class SqlStorage:
                 continue
             else:
                 excluded.append(f'"{col}" = EXCLUDED."{col}"')
-        excluded = ', '.join(excluded)
+        return ', '.join(excluded)
+
+    def upsert(self, cursor, tablename, obj, query_id):
+        colnames = obj.keys()
+        excluded = self._get_excluded(colnames, tablename)
         valnames = ', '.join([f'"{x}"' for x in colnames])
-        placeholders = ', '.join([f"({', '.join([self.placeholder] * len(colnames))})"] * len(objs))
-        stmt = (f'INSERT INTO "{tablename}" ({valnames}) VALUES {placeholders}'
+        placeholders = ', '.join([self.placeholder] * len(obj))
+        stmt = (f'INSERT INTO "{tablename}" ({valnames}) VALUES ({placeholders})'
                 f' ON CONFLICT (id) DO UPDATE SET {excluded};')
-        values = []
-        query_values = []
-        for obj in objs:
-            query_values.append(obj['id'])
-            query_values.append(query_id)
-            for c in colnames:
-                if obj.get(c):
-                    value = obj[c]
-                    values.append(str(orjson.dumps(value), 'utf-8') if isinstance(value, list) else value)
-                else:
-                    values.append(None)
+        values = tuple([str(orjson.dumps(value), 'utf-8')
+                        if isinstance(value, list) else value for value in obj.values()])
         logger.debug('_upsert: "%s"', stmt)
         cursor.execute(stmt, values)
 
         # Now add to query table as well
-        placeholders = ', '.join([f'({self.placeholder}, {self.placeholder})'] * len(objs))
         stmt = (f'INSERT INTO "__queries" (sco_id, query_id)'
-                f' VALUES {placeholders}')
-        cursor.execute(stmt, query_values)
+                f' VALUES ({self.placeholder}, {self.placeholder})')
+        cursor.execute(stmt, (obj['id'], query_id))
+
+    def upsert_many(self, cursor, tablename, objs, query_id):
+        for obj in objs:
+            self.upsert(cursor, tablename, obj, query_id)
 
     def cache(self, query_id, bundles):
         """Cache the result of a query"""


### PR DESCRIPTION
As title, when inserting values into database, this change insert multiple rows of values. My local tests showed that it reduced a 20k-stix-bundle insertion time from 2 minutes to 8 seconds.