### PR TITLE
Aggregated entity support

### DIFF
--- a/firepit/pgstorage.py
+++ b/firepit/pgstorage.py
@@ -41,6 +41,7 @@ class PgStorage(SqlStorage):
         self.text_max = 'GREATEST'
         self.ifnull = 'COALESCE'
         self.dbname = dbname
+        self.infer_type = _infer_type
         if not session_id:
             session_id = 'firepit'
         self.session_id = session_id
@@ -108,10 +109,11 @@ class PgStorage(SqlStorage):
             logger.debug("Closing PostgreSQL DB connection")
             self.connection.close()
 
-    def _query(self, query, values=None):
+    def _query(self, query, values=None, cursor=None):
         """Private wrapper for logging SQL query"""
         logger.debug('Executing query: %s', query)
-        cursor = self.connection.cursor()
+        if not cursor:
+            cursor = self.connection.cursor()
         if not values:
             values = ()
         try:
@@ -161,12 +163,18 @@ class PgStorage(SqlStorage):
         validate_name(viewname)
         if not cursor:
             cursor = self._execute('BEGIN;')
+        is_new = True
         if not deps:
             deps = []
         elif viewname in deps:
+            is_new = False
             # Get the query that makes up the current view
             slct = self._get_view_def(viewname)
-            self._execute(f'DROP VIEW IF EXISTS "{viewname}"', cursor)
+            if self._is_sql_view(viewname, cursor):
+                self._execute(f'DROP VIEW IF EXISTS "{viewname}"', cursor)
+            else:
+                self._execute(f'ALTER TABLE "{viewname}" RENAME TO "_{viewname}"', cursor)
+                slct = slct.replace(viewname, f'_{viewname}')
             # Swap out the viewname for its definition
             select = re.sub(f'"{viewname}"', f'({slct}) AS tmp', select)
         try:
@@ -183,7 +191,9 @@ class PgStorage(SqlStorage):
             cursor = self._execute('BEGIN;')
             self._execute(f'DROP VIEW IF EXISTS "{viewname}";', cursor)
             self._execute(f'CREATE VIEW "{viewname}" AS {select}', cursor)
-        self._new_name(cursor, viewname, sco_type)
+            is_new = False
+        if is_new:
+            self._new_name(cursor, viewname, sco_type)
         return cursor
 
     def _get_view_def(self, viewname):
@@ -192,28 +202,43 @@ class PgStorage(SqlStorage):
                              " WHERE schemaname = %s"
                              " AND viewname = %s", (self.session_id, viewname))
         viewdef = cursor.fetchone()
-        stmt = viewdef['definition'].rstrip(';')
+        if viewdef:
+            stmt = viewdef['definition'].rstrip(';')
 
-        # PostgreSQL will "expand" the original "*" to the columns
-        # that existed at that time.  We need to get the star back, to
-        # match SQLite3's behavior.
-        return re.sub(r'^.*?FROM', 'SELECT * FROM', stmt, 1, re.DOTALL)
+            # PostgreSQL will "expand" the original "*" to the columns
+            # that existed at that time.  We need to get the star back, to
+            # match SQLite3's behavior.
+            return re.sub(r'^.*?FROM', 'SELECT * FROM', stmt, 1, re.DOTALL)
+
+        # Must be a table
+        return f'SELECT * FROM "{viewname}"'
+
+    def _is_sql_view(self, name, cursor=None):
+        cursor = self._query("SELECT definition"
+                             " FROM pg_views"
+                             " WHERE schemaname = %s"
+                             " AND viewname = %s", (self.session_id, name))
+        viewdef = cursor.fetchone()
+        return viewdef is not None
 
     def tables(self):
         cursor = self._query("SELECT table_name"
                              " FROM information_schema.tables"
-                             " WHERE table_schema = %s", (self.session_id, ))
+                             " WHERE table_schema = %s"
+                             "   AND table_type != 'VIEW'", (self.session_id, ))
         rows = cursor.fetchall()
         return [i['table_name'] for i in rows
                 if not i['table_name'].startswith('__')]
 
-    def views(self):
-        cursor = self._query("SELECT table_name"
-                             " FROM information_schema.tables"
-                             " WHERE table_schema = %s"
-                             " AND table_type = 'VIEW'", (self.session_id, ))
+    def types(self):
+        stmt = ("SELECT table_name FROM information_schema.tables"
+                " WHERE table_schema = %s AND table_type != 'VIEW'"
+                "  EXCEPT SELECT name as table_name FROM __symtable")
+        cursor = self._query(stmt, (self.session_id, ))
         rows = cursor.fetchall()
-        return [i['table_name'] for i in rows]
+        # Ignore names that start with 1 or 2 underscores
+        return [i['table_name'] for i in rows
+                if not i['table_name'].startswith('_')]
 
     def columns(self, viewname):
         validate_name(viewname)
@@ -251,13 +276,15 @@ class PgStorage(SqlStorage):
             action = f'UPDATE SET {excluded}'
         valnames = ', '.join([f'"{x}"' for x in colnames])
         placeholders = ', '.join([f"({', '.join([self.placeholder] * len(colnames))})"] * len(objs))
-        stmt = (f'INSERT INTO "{tablename}" ({valnames}) VALUES {placeholders}'
-                f' ON CONFLICT (id) DO {action};')
+        stmt = f'INSERT INTO "{tablename}" ({valnames}) VALUES {placeholders}'
+        if 'id' in colnames:
+            stmt += f' ON CONFLICT (id) DO {action}'
         values = []
         query_values = []
         for obj in objs:
-            query_values.append(obj['id'])
-            query_values.append(query_id)
+            if query_id:
+                query_values.append(obj['id'])
+                query_values.append(query_id)
             for c in colnames:
                 value = obj.get(c, None)
                 values.append(str(orjson.dumps(value), 'utf-8') if isinstance(value, list) else value)
@@ -265,8 +292,9 @@ class PgStorage(SqlStorage):
                      len(objs), tablename, valnames, action)
         cursor.execute(stmt, values)
 
-        # Now add to query table as well
-        placeholders = ', '.join([f'({self.placeholder}, {self.placeholder})'] * len(objs))
-        stmt = (f'INSERT INTO "__queries" (sco_id, query_id)'
-                f' VALUES {placeholders}')
-        cursor.execute(stmt, query_values)
+        if query_id:
+            # Now add to query table as well
+            placeholders = ', '.join([f'({self.placeholder}, {self.placeholder})'] * len(objs))
+            stmt = (f'INSERT INTO "__queries" (sco_id, query_id)'
+                    f' VALUES {placeholders}')
+            cursor.execute(stmt, query_values)

--- a/firepit/pgstorage.py
+++ b/firepit/pgstorage.py
@@ -86,9 +86,6 @@ class PgStorage(SqlStorage):
             stmt = ('CREATE UNLOGGED TABLE IF NOT EXISTS "__symtable" '
                     '(name TEXT, type TEXT, appdata TEXT);')
             self._execute(stmt, cursor)
-            stmt = ('CREATE UNLOGGED TABLE IF NOT EXISTS "__membership" '
-                    '(sco_id TEXT, var TEXT);')
-            self._execute(stmt, cursor)
             stmt = ('CREATE UNLOGGED TABLE IF NOT EXISTS "__queries" '
                     '(sco_id TEXT, query_id TEXT);')
             self._execute(stmt, cursor)

--- a/firepit/sqlitestorage.py
+++ b/firepit/sqlitestorage.py
@@ -1,10 +1,8 @@
 import ipaddress
 import logging
 import os
-import random
 import re
 import sqlite3
-import string
 
 from firepit.exceptions import DuplicateTable
 from firepit.exceptions import InvalidAttr
@@ -131,7 +129,7 @@ class SQLiteStorage(SqlStorage):
             self.connection.rollback()
             logger.debug('_create_table: %s', e)  #, exc_info=e)
             if e.args[0].startswith(f'table "{tablename}" already exists'):
-                raise DuplicateTable(tablename)
+                raise DuplicateTable(tablename) from e
         if 'x_contained_by_ref' in columns:
             self._execute(f'CREATE INDEX "{tablename}_obs" ON "{tablename}" ("x_contained_by_ref");', cursor)
         self.connection.commit()
@@ -147,7 +145,7 @@ class SQLiteStorage(SqlStorage):
         except sqlite3.OperationalError as e:
             self.connection.rollback()
             logger.debug('%s', e)  #, exc_info=e)
-            if e.args[0].startswith(f'duplicate column name: '):
+            if e.args[0].startswith('duplicate column name: '):
                 pass
             else:
                 raise Exception('Internal error: ' + e.args[0]) from e

--- a/firepit/sqlitestorage.py
+++ b/firepit/sqlitestorage.py
@@ -88,8 +88,8 @@ class SQLiteStorage(SqlStorage):
     def _execute(self, statement, cursor=None):
         return self._do_execute(statement, cursor=cursor)
 
-    def _query(self, query, values=None):
-        cursor = self._do_execute(query, values=values)
+    def _query(self, query, values=None, cursor=None):
+        cursor = self._do_execute(query, values=values, cursor=cursor)
         self.connection.commit()
         return cursor
 
@@ -98,19 +98,26 @@ class SQLiteStorage(SqlStorage):
         validate_name(viewname)
         if not cursor:
             cursor = self._execute('BEGIN;')
+        is_new = True
         if not deps:
             deps = []
         elif viewname in deps:
-            # Rename old view to random var
-            tmp = ''.join(random.choice(string.ascii_lowercase)
-                          for x in range(8))
-            self._execute(f'DROP VIEW IF EXISTS "{tmp}"', cursor)
+            is_new = False
+            # Get the query that makes up the current view
             slct = self._get_view_def(viewname)
-            self._create_view(tmp, slct, sco_type, cursor=cursor)
-            select = re.sub(f'"{viewname}"', tmp, select)
-        self._execute(f'DROP VIEW IF EXISTS "{viewname}"', cursor)
+            if self._is_sql_view(viewname, cursor):
+                self._execute(f'DROP VIEW IF EXISTS "{viewname}"', cursor)
+            else:
+                self._execute(f'ALTER TABLE "{viewname}" RENAME TO "_{viewname}"', cursor)
+                slct = slct.replace(viewname, f'_{viewname}')
+            # Swap out the viewname for its definition
+            select = re.sub(f'"{viewname}"', f'({slct}) AS tmp', select)
+        if self._is_sql_view(viewname, cursor):
+            is_new = False
+            self._execute(f'DROP VIEW IF EXISTS "{viewname}"', cursor)
         self._execute(f'CREATE VIEW "{viewname}" AS {select}', cursor)
-        self._new_name(cursor, viewname, sco_type)
+        if is_new:
+            self._new_name(cursor, viewname, sco_type)
         return cursor
 
     def _create_table(self, tablename, columns):
@@ -149,8 +156,18 @@ class SQLiteStorage(SqlStorage):
         view = self._query(("SELECT sql from sqlite_master"
                             " WHERE type='view' and name=?"),
                            values=(viewname,)).fetchone()
-        slct = view['sql']
-        return slct.replace(f'CREATE VIEW "{viewname}" AS ', '')
+        if view:
+            slct = view['sql']
+            return slct.replace(f'CREATE VIEW "{viewname}" AS ', '')
+
+        # Must be a table
+        return f'SELECT * FROM "{viewname}"'
+
+    def _is_sql_view(self, name, cursor=None):
+        view = self._query(("SELECT sql from sqlite_master"
+                            " WHERE type='view' and name=?"),
+                           values=(name,)).fetchone()
+        return view is not None
 
     def tables(self):
         cursor = self.connection.execute(
@@ -160,11 +177,14 @@ class SQLiteStorage(SqlStorage):
                 if not i['name'].startswith('__') and
                 not i['name'].startswith('sqlite')]
 
-    def views(self):
-        cursor = self.connection.execute(
-            "SELECT name FROM sqlite_master WHERE type='view';")
+    def types(self):
+        stmt = ("SELECT name FROM sqlite_master WHERE type='table'"
+                " EXCEPT SELECT name FROM __symtable")
+        cursor = self.connection.execute(stmt)
         rows = cursor.fetchall()
-        return [i['name'] for i in rows]
+        return [i['name'] for i in rows
+                if not i['name'].startswith('__') and
+                not i['name'].startswith('sqlite')]
 
     def columns(self, viewname):
         validate_name(viewname)

--- a/firepit/sqlstorage.py
+++ b/firepit/sqlstorage.py
@@ -213,10 +213,7 @@ class SqlStorage:
                   f'  INNER JOIN __queries ON "{sco_type}".id = __queries.sco_id'
                   f'  WHERE {where});')
 
-        try:
-            cursor = self._create_view(viewname, select, sco_type, deps=[tablename], cursor=cursor)
-        except IncompatibleType:
-            raise IncompatibleType(f'{viewname} has type "{old_type}"; cannot assign type "{sco_type}"')
+        cursor = self._create_view(viewname, select, sco_type, deps=[tablename], cursor=cursor)
         self.connection.commit()
         cursor.close()
 

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -281,8 +281,6 @@ def test_reassign(fake_bundle_file, fake_csv_file, tmpdir):
 
     # Now reload into the same var
     store.reassign('urls', urls)
-    rows = store.lookup('__membership')
-    print(ujson.dumps(rows, indent=4))
     rows = store.lookup('urls')
     print(ujson.dumps(rows, indent=4))
     assert len(rows) == len(urls)
@@ -493,9 +491,3 @@ def test_clobber_viewname(fake_bundle_file_2, tmpdir):
     # conns2 should be no more:
     with pytest.raises(UnknownViewname):
         store.lookup('conns2')
-
-    # Poke around more
-    cursor = store.connection.cursor()
-    cursor.execute("SELECT COUNT(*) c FROM __membership WHERE var = 'conns2'")
-    res = cursor.fetchall()
-    assert res[0]['c'] == 0


### PR DESCRIPTION
- eliminates `__membership` table
- converts aggregated (i.e. grouped) view to table
- add new `types()` API to get a list of tables that represent SCO types (in other words tables that weren't converted from views)