### PR TITLE
1.3.5

### DIFF
--- a/firepit/__init__.py
+++ b/firepit/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """IBM Security"""
 __email__ = 'pcoccoli@us.ibm.com'
-__version__ = '1.3.4'
+__version__ = '1.3.5'
 
 
 from importlib import import_module

--- a/firepit/splitter.py
+++ b/firepit/splitter.py
@@ -114,6 +114,7 @@ class SqlWriter:
     def write_records(self, obj_type, records, schema, replace, query_id):
         tablename = f'{self.prefix}{obj_type}'
         try:
+            self.store.connection.commit()
             cursor = self.store.connection.cursor()
             cursor.execute('BEGIN')
             if replace:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.3.4
+current_version = 1.3.5
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/opencybersecurityalliance/firepit',
-    version='1.3.4',
+    version='1.3.5',
     zip_safe=False,
 )


### PR DESCRIPTION
In splitter:write_records(), do a pre-emptive commit in case there's a transaction open already.  I'm not sure why there would be, but I've seen evidence that it's possible.