### PR TITLE
2.0.2

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -24,5 +24,10 @@ jobs:
         run: |
           python -m pip install --upgrade pip wheel
           make setup
-      - name: Run all tests
-        run: make test
+      - name: Run tests with coverage assessment
+        run: make test-cov
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          fail_ci_if_error: true
+          verbose: true

--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,9 @@ test: ## run tests quickly with the default Python
 test-all: ## run tests on every Python version with tox
 	tox
 
+test-cov: ## run tests with code coverage assessment
+	pytest --cov=firepit --cov-report=xml
+
 coverage: ## check code coverage quickly with the default Python
 	coverage run --source firepit -m pytest
 	coverage report -m

--- a/README.rst
+++ b/README.rst
@@ -14,6 +14,9 @@ Firepit - STIX Columnar Storage
         :target: https://github.com/opencybersecurityalliance/firepit
         :alt: Unit Test Status
 
+.. image:: https://codecov.io/gh/opencybersecurityalliance/firepit/branch/develop/graph/badge.svg?token=Pu7pkqmE5W
+        :target: https://codecov.io/gh/opencybersecurityalliance/firepit
+
 
 Columnar storage for STIX 2.0 observations.
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - "tests"

--- a/firepit/__init__.py
+++ b/firepit/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """IBM Security"""
 __email__ = 'pcoccoli@us.ibm.com'
-__version__ = '2.0.1'
+__version__ = '2.0.2'
 
 
 import re

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -8,6 +8,7 @@ twine
 stix2
 
 pytest
+pytest-cov
 pytest-runner
 pylint
 bandit

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.0.1
+current_version = 2.0.2
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/opencybersecurityalliance/firepit',
-    version='2.0.1',
+    version='2.0.2',
     zip_safe=False,
 )


### PR DESCRIPTION
Fix an issue in the `reassign` function that only happens on postgres:
```
  File "/opt/modules/lib/python3.9/site-packages/firepit/sqlstorage.py", line 475, in reassign
    splitter.write(obj)
  File "/opt/modules/lib/python3.9/site-packages/firepit/splitter.py", line 243, in write
    self.writer.new_property(obj_type, col, col_type)
  File "/opt/modules/lib/python3.9/site-packages/firepit/splitter.py", line 109, in new_property
    self.store._add_column(tablename, prop_name, prop_type)
  File "/opt/modules/lib/python3.9/site-packages/firepit/pgstorage.py", line 277, in _add_column
    self._execute(f'DROP VIEW IF EXISTS "{viewname}"', cursor)
  File "/opt/modules/lib/python3.9/site-packages/firepit/sqlstorage.py", line 146, in _execute
    cursor.execute(statement)
  File "/opt/modules/lib/python3.9/site-packages/psycopg2/extras.py", line 236, in execute
    return super().execute(query, vars)
psycopg2.errors.DependentObjectsStillExist: cannot drop view process_0 because other objects depend on it
```