### PR TITLE
v2.3.1

### DIFF
--- a/firepit/__init__.py
+++ b/firepit/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """IBM Security"""
 __email__ = 'pcoccoli@us.ibm.com'
-__version__ = '2.3.0'
+__version__ = '2.3.1'
 
 
 import re

--- a/firepit/sqlstorage.py
+++ b/firepit/sqlstorage.py
@@ -155,7 +155,7 @@ class SqlStorage:
 
     def _drop_name(self, cursor, name):
         stmt = f'DELETE FROM "__symtable" WHERE name = {self.placeholder};'
-        cursor.execute(stmt, (name,))
+        self._query(stmt, (name,), cursor)  # This commits
 
     def _execute(self, statement, cursor=None):
         """Private wrapper for logging SQL statements"""
@@ -755,14 +755,10 @@ class SqlStorage:
         cursor = self._execute('BEGIN;')
 
         # Need to remove `newname` if it already exists
-        self._execute(f'DROP VIEW IF EXISTS "{newname}";', cursor)
         self._drop_name(cursor, newname)
 
         # Now do the rename
-        qry = re.sub(f'var = \'{oldname}\'',  # This is an ugly hack
-                     f'var = \'{newname}\'',
-                     view_def)
-        self._create_view(newname, qry, view_type, cursor=cursor)
+        self._create_view(newname, view_def, view_type, cursor=cursor)
         self._execute(f'DROP VIEW IF EXISTS "{oldname}"', cursor)
         self._drop_name(cursor, oldname)
         self._new_name(cursor, newname, view_type)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.3.0
+current_version = 2.3.1
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/opencybersecurityalliance/firepit',
-    version='2.3.0',
+    version='2.3.1',
     zip_safe=False,
 )


### PR DESCRIPTION
Add a unique constraint to the `name` column of `__symtable`, which is a table of all user-created views.  This should prevent duplicate records, which was causing issues with PostgreSQL when re-running steps.