### PR TITLE
2.3.6

### DIFF
--- a/firepit/__init__.py
+++ b/firepit/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """IBM Security"""
 __email__ = 'pcoccoli@us.ibm.com'
-__version__ = '2.3.5'
+__version__ = '2.3.6'
 
 
 import re

--- a/firepit/props.py
+++ b/firepit/props.py
@@ -332,8 +332,11 @@ def prop_metadata(sco_type, prop):
     meta = KNOWN_PROPS.get(sco_type, {}).get(prop)
     if not meta:
         links = parse_prop(sco_type, prop)  # Maybe just do this first?
-        _, ref_type, ref_prop = links[-1]
-        meta = KNOWN_PROPS.get(ref_type, {}).get(ref_prop, {})
+        if links:
+            _, ref_type, ref_prop = links[-1]
+            meta = KNOWN_PROPS.get(ref_type, {}).get(ref_prop, {})
+        else:
+            meta = {}
     if 'dtype' not in meta:
         meta['dtype'] = 'str'
     if 'ftype' not in meta:

--- a/firepit/raft.py
+++ b/firepit/raft.py
@@ -161,7 +161,8 @@ def flatten_21(obj):
     For STIX 2.1 objects, "flatten" references
     """
     results = [obj]
-    oid = obj['id']
+    oid = str(obj['id'])
+    obj['id'] = oid  # Ensure it's a plain string
 
     obj_type = obj['type']
     if obj_type == 'identity':
@@ -172,7 +173,7 @@ def flatten_21(obj):
             results.append({
                 'type': '__contains',
                 'source_ref': oid,
-                'target_ref': ref
+                'target_ref': str(ref)
             })
         del obj['object_refs']
         return results
@@ -180,11 +181,14 @@ def flatten_21(obj):
     # Create SRO for ref lists
     ref_lists = []
     for prop, val in obj.items():
-        if prop.endswith('_refs'):
+        if prop.endswith('_ref'):
+            obj[prop] = str(val)  # Ensure it's a plain string
+        elif prop.endswith('_refs'):
             if not isinstance(val, list):
                 val = [val]
             if prop != 'object_refs':
                 for ref in val:
+                    ref = str(ref)  # Ensure it's a plain string
                     if ref != oid:  # Avoid bogus references
                         sro = {
                             'type': '__reflist',

--- a/firepit/splitter.py
+++ b/firepit/splitter.py
@@ -6,6 +6,7 @@ from collections import OrderedDict, defaultdict
 import ujson
 
 from firepit.exceptions import DuplicateTable
+from firepit.exceptions import InvalidObject
 
 
 logger = logging.getLogger(__name__)
@@ -221,6 +222,8 @@ class SplitWriter:
         """Consume `obj` (actual writing to storage may be deferred)"""
         obj.update(self.extras)
         obj_type = obj['type']
+        if not obj_type:
+            raise InvalidObject('empty `type` property')
         schema = self.schemas.get(obj_type)
         add_table = False
         add_col = False

--- a/firepit/splitter.py
+++ b/firepit/splitter.py
@@ -237,7 +237,10 @@ class SplitWriter:
             if key in ['type', 'spec_version']:
                 continue
             # shorten key (STIX prop) to make column names more manageable
-            shortname = self.writer.shorten(key)  # Need to detect collisions!
+            if len(key) > 63 or 'extensions.' in key:
+                shortname = self.writer.shorten(key)  # Need to detect collisions!
+            else:
+                shortname = key
             new_obj[shortname] = value
             if shortname not in schema:
                 # Found new column

--- a/firepit/sqlstorage.py
+++ b/firepit/sqlstorage.py
@@ -50,7 +50,7 @@ def _transform(filename):
     for obj in raft.get_objects(filename):  #, ['identity', 'observed-data']):
         # Some identity objects from stix-shifter are missing a `type` property?
         if 'type' not in obj:
-            obj['type'], _, _ = obj['id'].partition('--')
+            obj['type'], _, _ = obj['id'].rpartition('--')
         if obj['type'] != 'identity':
             for o in (raft.json_normalize(obj, flat_lists=False)
                       for obj in raft.flatten(obj)):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.3.5
+current_version = 2.3.6
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/opencybersecurityalliance/firepit',
-    version='2.3.5',
+    version='2.3.6',
     zip_safe=False,
 )

--- a/tests/test_props.py
+++ b/tests/test_props.py
@@ -16,6 +16,9 @@ from firepit.props import prop_metadata
         ('process', 'name'),
         ('url', 'value'),
         ('user-account', 'user_id'),
+
+        # Negative cases
+        #TODO: Not sure what the behavior should be: ('x-unknown-type', None),
     ]
 )
 def test_primary_prop(sco_type, expected):
@@ -72,6 +75,10 @@ def test_path_metadata(path, dtype, ftype):
         ('file',  'name', 'str', 'categorical'),
         ('network-traffic', 'src_ref.value', 'str', 'categorical'),
         ('x-oca-event', 'network_ref.dst_byte_count', 'int', 'numerical'),
+
+        # Negative cases
+        ('x-unknown-type', 'unknown_ref.value', 'str', 'categorical'),
+        ('x-oca-event', 'unknown_ref.value', 'str', 'categorical'),
     ]
 )
 def test_prop_metadata(sco_type, prop, dtype, ftype):


### PR DESCRIPTION
Fixes:
- potential IndexError in prop_metadata
- handle missing SCO `type` value
- force SCO/SDO `id` value to `str`
Changes:
- slight optimization to `flatten` to avoid expensive prop shortening regex when not needed