### PR TITLE
Fix conversion of STIX string literal escapes to SQL string literal escapes

### DIFF
--- a/firepit/cli.py
+++ b/firepit/cli.py
@@ -61,12 +61,13 @@ def cache(
     query_id: str = typer.Argument(..., help="An identifier for this set of data"),
     filenames: List[str] = typer.Argument(..., help="STIX bundle files of query results"),
     batchsize: int = typer.Option(2000, help="Max objects to insert per statement"),
+    copy: bool = typer.Option(False, help="Use COPY (PostgreSQL only)"),
 ):
     """Cache STIX observation data in SQL"""
     db = get_storage(state['dbname'], state['session'])
     if isinstance(filenames, tuple):
         filenames = list(filenames)
-    db.cache(query_id, filenames, batchsize)
+    db.cache(query_id, filenames, batchsize, use_copy=copy)
 
 
 @app.command()

--- a/firepit/paramstix.lark
+++ b/firepit/paramstix.lark
@@ -43,7 +43,7 @@ ISOTIMESTAMP: /\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d(\.\d+)?Z/
 
 list: "(" literal ("," literal)* ")" -> lit_list
 
-?literal: "'" /[^']+/ "'" -> quoted_str
+?literal: "'" /((\\')|[^'])+/ "'" -> quoted_str
         | NUMBER
 
 reference: ECNAME "." PATH

--- a/firepit/sqlstorage.py
+++ b/firepit/sqlstorage.py
@@ -343,7 +343,7 @@ class SqlStorage:
         validate_name(viewname)
         validate_name(tablename)
         try:
-            where = stix2sql(pattern, sco_type) if pattern else None
+            where = stix2sql(pattern, sco_type, self.dialect) if pattern else None
         except Exception as e:
             logger.error('%s', e)
             raise StixPatternError(pattern) from e
@@ -589,7 +589,7 @@ class SqlStorage:
                      sco_type, viewname, input_view, pattern)
         slct = self._get_view_def(input_view)
         try:
-            where = stix2sql(pattern, sco_type) if pattern else None
+            where = stix2sql(pattern, sco_type, self.dialect) if pattern else None
         except Exception as e:
             logger.error('%s', e)
             raise StixPatternError(pattern) from e

--- a/tests/test_matching.py
+++ b/tests/test_matching.py
@@ -39,6 +39,21 @@ def test_like(one_event_bundle, tmpdir):
     assert len(s) == 1
 
 
+def test_like_regkey(regkey_bundle, tmpdir):
+    store = tmp_storage(tmpdir)
+    store.cache('q1', regkey_bundle)
+
+    # Match using STIX pattern and LIKE operator
+    store.extract(
+        'x',
+        'windows-registry-key',
+        'q1',
+        r"[windows-registry-key:key LIKE '%\\Microsoft\\Windows\\CurrentVersion\\Run%']",
+    )
+    x = store.lookup('x')
+    assert len(x) == 1
+
+
 def test_matches(one_event_bundle, tmpdir):
     store = tmp_storage(tmpdir)
     store.cache('q1', one_event_bundle)
@@ -48,7 +63,7 @@ def test_matches(one_event_bundle, tmpdir):
         'x',
         'artifact',
         'q1',
-        r"[artifact:payload_bin MATCHES '(Ing|E)ressInterface=ethernet1/\d']",
+        r"[artifact:payload_bin MATCHES '(Ing|E)ressInterface=ethernet1/\\d']",
     )
     x = store.lookup('x')
     assert len(x) == 1
@@ -75,3 +90,31 @@ def test_matches_regkey(regkey_bundle, tmpdir):
     )
     x = store.lookup('x')
     assert len(x) == 1
+
+
+def test_equal_commandline_backslash(ccoe_bundle, tmpdir):
+    store = tmp_storage(tmpdir)
+    store.cache('q1', [ccoe_bundle])
+
+    store.extract(
+        'procs',
+        'process',
+        'q1',
+        r"[process:command_line = 'C:\\WINDOWS\\system32\\services.exe']"
+    )
+    procs = store.lookup('procs')
+    assert len(procs) == 2
+
+
+def test_like_commandline_apostrophe(ccoe_bundle, tmpdir):
+    store = tmp_storage(tmpdir)
+    store.cache('q1', [ccoe_bundle])
+
+    store.extract(
+        'procs',
+        'process',
+        'q1',
+        r"[process:command_line LIKE '%DownloadString(\'%\')%']"
+    )
+    procs = store.lookup('procs')
+    assert len(procs) == 5

--- a/tests/test_matching.py
+++ b/tests/test_matching.py
@@ -92,6 +92,20 @@ def test_matches_regkey(regkey_bundle, tmpdir):
     assert len(x) == 1
 
 
+def test_matches_commandline_literal_dot(ccoe_bundle, tmpdir):
+    store = tmp_storage(tmpdir)
+    store.cache('q1', [ccoe_bundle])
+
+    store.extract(
+        'procs',
+        'process',
+        'q1',
+        r"[process:command_line MATCHES '^C:\\\\WINDOWS\\\\system32\\\\services\\.exe$']"
+    )
+    procs = store.lookup('procs')
+    assert len(procs) == 2
+
+
 def test_equal_commandline_backslash(ccoe_bundle, tmpdir):
     store = tmp_storage(tmpdir)
     store.cache('q1', [ccoe_bundle])

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -113,10 +113,8 @@ def test_basic(fake_bundle_file, fake_csv_file, tmpdir):
     print(grouped_users)
     henry = next((item for item in grouped_users if item['account_login'] == 'henry'), None)
     assert henry
-    #assert henry['number_observed'] == 2
     isabel = next((item for item in grouped_users if item['account_login'] == 'isabel'), None)
     assert isabel
-    #assert isabel['number_observed'] == 12
 
     with open(fake_csv_file, newline='') as fp:
         reader = csv.DictReader(fp)
@@ -134,8 +132,8 @@ def test_basic(fake_bundle_file, fake_csv_file, tmpdir):
     ids = [row['id'] for row in rows]
     assert 'process--41eb677f-0335-49da-98b8-375e22f8c94e_0' in ids
     assert 'process--0bb2e61f-8c88-415d-bb7a-bcffc991c38e_0' in ids
-    #assert rows[1]['binary_ref.parent_directory_ref.path'] == 'C:\\Windows\\System32'
-    #assert rows[2]['parent_ref.command_line'] == 'C:\\windows\\system32\\cmd.exe /c "reg delete HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Run /v caldera /f"'
+    assert rows[1]['binary_ref.parent_directory_ref.path'] == 'C:\\Windows\\System32'
+    assert rows[2]['parent_ref.command_line'] == 'C:\\windows\\system32\\cmd.exe /c "reg delete HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Run /v caldera /f"'
 
     ips = ['10.0.0.1', '10.0.0.2']
     res = store.load('test_ips', ips, sco_type='ipv4-addr')


### PR DESCRIPTION
`MATCHES` and `LIKE` with backslashes in the value (e.g. Windows paths and registry keys, but also regular expressions) were not handled correctly and consistently.  This change converts the escapes from what STIX uses to what SQL requires (including a "hack" to handle non-conforming behavior from PostgreSQL's `LIKE` handling, where it uses '\' for the escape character instead of `'`).