### PR TITLE
2.3.30

### DIFF
--- a/firepit/__init__.py
+++ b/firepit/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """IBM Security"""
 __email__ = 'pcoccoli@us.ibm.com'
-__version__ = '2.3.29'
+__version__ = '2.3.30'
 
 
 import re

--- a/firepit/aio/ingest.py
+++ b/firepit/aio/ingest.py
@@ -247,6 +247,9 @@ def translate(
     # columns we need to "unwrap"
     unwrap = set()
 
+    # "Unmapped" columns that we need to drop
+    unmapped = []
+
     logger.debug('columns: %s', cols)
     for col in cols:
         logger.debug('column: %s', col)
@@ -298,7 +301,10 @@ def translate(
         else:
             # Drop unmapped columns
             logger.debug('DROP unmapped column "%s"', col)
-            df = df.drop(col, axis=1)
+            unmapped.append(col)
+
+    # Drop any columns that weren't mapped
+    df = df.drop(unmapped, axis=1)
 
     # Run transformers
     for txf_col, txf_name in txf_cols.items():

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.3.29
+current_version = 2.3.30
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/opencybersecurityalliance/firepit',
-    version='2.3.29',
+    version='2.3.30',
     zip_safe=False,
 )

--- a/tests/test_deref.py
+++ b/tests/test_deref.py
@@ -1,4 +1,7 @@
 from firepit.deref import auto_deref, auto_deref_cached
+from firepit.query import Query
+from firepit.query import Order
+from firepit.query import Table
 from firepit.sqlstorage import _get_col_dict
 from .helpers import tmp_storage
 
@@ -78,3 +81,10 @@ def test_deref_mixed(mixed_v4_v6_bundle, tmpdir):
     assert 'COALESCE(dst_ref4.value, dst_ref6.value) AS "dst_ref.value"' in result_cols
     assert 'COALESCE(dst_ref4.id, dst_ref6.id) AS "dst_ref.id"' in result_cols
     assert '"dst_ref4"."x_enrich" AS "dst_ref.x_enrich"' in result_cols
+
+    query = Query([
+        Table('conns'),
+        Order([('dst_ref.value', Order.ASC)]),
+    ])
+    store.assign_query('sconns', query)
+    _ = store.lookup('sconns')

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -750,6 +750,7 @@ def test_assign_query_1(fake_bundle_file, tmpdir):
     store.assign_query('conns', query)
     srcs = store.values('src_ref.value', 'conns')
     assert srcs[0] > srcs[-1]
+    assert srcs == sorted(srcs, reverse=True)
 
 
 def test_number_observed(fake_bundle_file, tmpdir):


### PR DESCRIPTION
- ingest: drop all unmapped columns at once, which is much faster
- Don't add table name to ref'ed prop in assign_query (#113)